### PR TITLE
Run using Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,5 +12,5 @@ outputs:
   teller-version:
     description: "The Teller version that was installed."
 runs:
-  using: "node12"
+  using: "node16"
   main: "main.js"


### PR DESCRIPTION
Actions using Node 12 has been deprecated since September 22, 2022. See https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.